### PR TITLE
Adding 'toElliptic' method to 'PrivateKey' class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wireio/core",
   "description": "Library for working with Wire powered blockchains.",
-  "version": "0.0.5-9",
+  "version": "0.0.6",
   "homepage": "https://github.com/Wire-Network/sdk-core",
   "license": "FSL-1.1-Apache-2.0",
   "main": "lib/core.js",

--- a/src/chain/private-key.ts
+++ b/src/chain/private-key.ts
@@ -16,6 +16,7 @@ import {
     Checksum256,
     Checksum256Type,
     Checksum512,
+    getCurve,
     KeyType,
     PublicKey,
     Signature,
@@ -172,6 +173,11 @@ export class PrivateKey {
         }
 
         return Base58.encodeCheck(Bytes.from([0x80]).appending(this.data));
+    }
+
+    toElliptic(): EC.KeyPair {
+        const ec = getCurve(this.type);
+        return ec.keyFromPrivate(this.data.array);
     }
 
     /**


### PR DESCRIPTION
Changes to `PrivateKey` class:

* [`src/chain/private-key.ts`](diffhunk://#diff-53a72909eb3e78e1f05bc42ecaaea2a5f6711844474e6c9035238f4fbcb9619aR19): Added the `getCurve` import to support elliptic curve operations.
* [`src/chain/private-key.ts`](diffhunk://#diff-53a72909eb3e78e1f05bc42ecaaea2a5f6711844474e6c9035238f4fbcb9619aR178-R182): Introduced the `toElliptic` method in the `PrivateKey` class to convert the private key to an elliptic curve key pair.